### PR TITLE
Removes comments from `functions` output

### DIFF
--- a/fishtape.fish
+++ b/fishtape.fish
@@ -59,7 +59,7 @@ function fishtape -d "TAP producer and test harness for fish"
 
     awk (
         for name in runtime total locals reset setup count teardown
-          printf "%s\n" -v $name=(functions __fishtape@{$name} | sed '1d;$d;s/\\\/\\\\\\\/g' | paste -sd ';' -)
+          printf "%s\n" -v $name=(functions __fishtape@{$name} | awk '/^#/ { next } { print }' | sed '1d;$d;s/\\\/\\\\\\\/g' | paste -sd ';' -)
         end
         ) '
 

--- a/test/sandbox.fish
+++ b/test/sandbox.fish
@@ -1,12 +1,12 @@
 set -l tally 0
 set -l proof false
 
-function -S setup
+function setup -S
     set proof true
     set tally (math 1 + $tally)
 end
 
-function -S teardown
+function teardown -S
     pass "$TESTNAME: teardown is called after running tests"
 end
 

--- a/test/scope.fish
+++ b/test/scope.fish
@@ -4,7 +4,7 @@ function setup
     set -g USER foo
 end
 
-function -S teardown
+function teardown -S
     set -l msg "$TESTNAME: globals are restored before teardown"
 
     if test $USER != foo


### PR DESCRIPTION
With fish-shell 2.6 and greater, `functions` outputs a comment showing
where the function is defined. This commit adds an additional `awk`
call to remove that comment, if it exists.

Fixes fisherman/fishtape#24

Also moves `-S` flag to the end of function definitions, as this is also broken in 2.5 or greater (https://github.com/fish-shell/fish-shell/pull/3574).