### PR TITLE
Use Ubuntu 14.04 for Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 before_install:
     - sudo add-apt-repository -y ppa:fish-shell/release-2
@@ -6,4 +7,3 @@ before_install:
 script:
     - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisherman
     - fish -c "fisher fishtape .; fishtape test/*.fish"
-    


### PR DESCRIPTION
The official fish-shell PPA does not build for 12.04 anymore.