### PR TITLE
Store status and return it after clean up

### DIFF
--- a/fishtape.fish
+++ b/fishtape.fish
@@ -171,6 +171,9 @@ function fishtape -d "TAP-based test runner"
                 }
             '
 
+            set -l test_status $status
+
             command rm -f @fishtape$tmp
+            return  $test_status
     end
 end


### PR DESCRIPTION
Because we cleanup after running the tests, if the tests fail we will return a status code of 0.

This stores the status code of our tests, does the cleanup and returns the status code. 

It fixes #47 