### PR TITLE
Add better support for failed not (!) tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Tests are defined with the `@test` function. Each test begins with a description
 @<a href=#writing-tests>test</a> <i>description</i> [<i>actual</i>] <a href=https://fishshell.com/docs/current/cmds/test.html#operators-for-files-and-directories>operator</a> <i>expected</i>
 </pre>
 
-> Operators to combine expressions are not currently supported: `!`, `-a`, `-o`.
+> Operators to combine expressions are not currently supported: `-a`, `-o`.
 
 Sometimes you need to test the exit status of running one or more commands and for that, you use command substitutions. Just make sure to suppress stdout to avoid cluttering your `test` expression.
 

--- a/functions/fishtape.fish
+++ b/functions/fishtape.fish
@@ -70,7 +70,7 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
                         set expected "not "$expectations[(contains --index -- $argv[2] $operators)]
                         set actual (string escape -- $argv[3])
                     else if set --query argv[3]
-                        set operator "$operator"$argv[2]
+                        set operator $argv[2]
                         set expected (string escape -- $argv[3])
                         set actual (string escape -- $argv[1])
                     else

--- a/functions/fishtape.fish
+++ b/functions/fishtape.fish
@@ -67,6 +67,7 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
 
                     if test $argv[1] = "!"
                         set operator "! "
+                        set negation "not "
                         set --erase argv[1]
                     end
 
@@ -76,7 +77,7 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
                         set actual (string escape -- $argv[1])
                     else
                         set operator "$operator"$argv[1]
-                        set expected $expectations[(contains --index -- $operator $operators)]
+                        set expected "$negation"$expectations[(contains --index -- $argv[1] $operators)]
                         set actual (string escape -- $argv[2])
                     end
 

--- a/functions/fishtape.fish
+++ b/functions/fishtape.fish
@@ -65,17 +65,19 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
                         string replace --filter --regex -- "\s+called on line (\d+) of file (.+)" '$2:$1' |
                         read --local at
 
-                    if test $argv[1] = "!" && set --query argv[3]
-                        set operator "$argv[1] $argv[2]"
-                        set expected "not "$expectations[(contains --index -- $argv[2] $operators)]
-                        set actual (string escape -- $argv[3])
-                    else if set --query argv[3]
-                        set operator $argv[2]
+                    if test $argv[1] = "!"
+                        set operator "! "
+                        set negation "not "
+                        set --erase argv[1]
+                    end
+
+                    if set --query argv[3]
+                        set operator "$operator"$argv[2]
                         set expected (string escape -- $argv[3])
                         set actual (string escape -- $argv[1])
                     else
-                        set operator $argv[1]
-                        set expected $expectations[(contains --index -- $operator $operators)]
+                        set operator "$operator"$argv[1]
+                        set expected "$negation"$expectations[(contains --index -- $argv[1] $operators)]
                         set actual (string escape -- $argv[2])
                     end
 

--- a/functions/fishtape.fish
+++ b/functions/fishtape.fish
@@ -65,12 +65,17 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
                         string replace --filter --regex -- "\s+called on line (\d+) of file (.+)" '$2:$1' |
                         read --local at
 
+                    if test $argv[1] = "!"
+                        set operator "! "
+                        set --erase argv[1]
+                    end
+
                     if set --query argv[3]
-                        set operator $argv[2]
+                        set operator "$operator"$argv[2]
                         set expected (string escape -- $argv[3])
                         set actual (string escape -- $argv[1])
                     else
-                        set operator $argv[1]
+                        set operator "$operator"$argv[1]
                         set expected $expectations[(contains --index -- $operator $operators)]
                         set actual (string escape -- $argv[2])
                     end

--- a/functions/fishtape.fish
+++ b/functions/fishtape.fish
@@ -65,19 +65,17 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
                         string replace --filter --regex -- "\s+called on line (\d+) of file (.+)" '$2:$1' |
                         read --local at
 
-                    if test $argv[1] = "!"
-                        set operator "! "
-                        set negation "not "
-                        set --erase argv[1]
-                    end
-
-                    if set --query argv[3]
+                    if test $argv[1] = "!" && set --query argv[3]
+                        set operator "$argv[1] $argv[2]"
+                        set expected "not "$expectations[(contains --index -- $argv[2] $operators)]
+                        set actual (string escape -- $argv[3])
+                    else if set --query argv[3]
                         set operator "$operator"$argv[2]
                         set expected (string escape -- $argv[3])
                         set actual (string escape -- $argv[1])
                     else
-                        set operator "$operator"$argv[1]
-                        set expected "$negation"$expectations[(contains --index -- $argv[1] $operators)]
+                        set operator $argv[1]
+                        set expected $expectations[(contains --index -- $argv[1] $operators)]
                         set actual (string escape -- $argv[2])
                     end
 

--- a/functions/fishtape.fish
+++ b/functions/fishtape.fish
@@ -75,7 +75,7 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
                         set actual (string escape -- $argv[1])
                     else
                         set operator $argv[1]
-                        set expected $expectations[(contains --index -- $argv[1] $operators)]
+                        set expected $expectations[(contains --index -- $operator $operators)]
                         set actual (string escape -- $argv[2])
                     end
 

--- a/tests/files.fish
+++ b/tests/files.fish
@@ -5,7 +5,9 @@ set temp (command mktemp -d)
 builtin cd $temp
 
 @test "a directory" -d $temp
+@test "a non-existent directory" ! -d $temp.fake
 @test "a regular file" (command touch file) -f file
+@test "a non-existent regular file" ! -f file.fake
 @test "nothing to see here" -z (read <file)
 
 command rm -rf $temp


### PR DESCRIPTION
String and numeric tests already have a negation test built-in as an operator (-ne, !=, etc), but for file system tests, there's not a specific operator. Instead, testing that a file or directory does not exist requires a two part operator, eg: `test ! -f myfile`. Fishtape does not output a great fail message for these tests because it doesn't account for the not (!) operator. This PR adds explicit support for not `!`.