### PR TITLE
fix: increase _fishtape_test_failed when file is invalid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,6 @@ jobs:
         run: |
           curl -sL https://git.io/fisher | source
           fisher install $GITHUB_WORKSPACE
-          fishtape tests/*
+          fishtape tests/invdalid.fish || true # should fail
+          fishtape (string match -v '*invalid*' -- tests/*)
         shell: fish {0}

--- a/functions/fishtape.fish
+++ b/functions/fishtape.fish
@@ -94,7 +94,8 @@ function fishtape --description "Test scripts, functions, and plugins in Fish"
             echo TAP version 13
 
             for file in $files
-                fish --init-command=(functions @echo | string collect) --init-command=(functions @test | string collect) $file
+                fish --init-command=(functions @echo | string collect) --init-command=(functions @test | string collect) $file \
+                    || set _fishtape_test_failed (math $_fishtape_test_failed + 1)
             end
 
             echo

--- a/tests/invalid.fish
+++ b/tests/invalid.fish
@@ -1,0 +1,4 @@
+@echo === invalid ===
+
+@test "a valid test but invalid file" true = true
+end # we want to trigger a parsing error


### PR DESCRIPTION
**related:** #60

Here, I reproduce a case of [silent error I got on pure](https://github.com/pure-fish/pure/pull/340#pullrequestreview-1840883015) due to an invalid file. The change was made through Github UI and _suggestion_ feature so no linting was done.

## Test
```
source ./functions/fishtape.fish; fishtape ./tests/invalid.fish
```

## CI
Not sure how to run this on CI